### PR TITLE
Update to yq v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ git pull origin main
 Bump podinfo version from `5.0.0` to `5.0.1`:
 
 ```sh
-yq w -i ./apps/podinfo/kustomization.yaml 'images[0].newTag' 5.0.1
+yq eval '.images[0].newTag="5.0.1"' -i ./apps/podinfo/kustomization.yaml
 ```
 
 Commit and push changes:
@@ -249,7 +249,7 @@ This is particularly useful for frontend applications that require session affin
 Enable A/B testing:
 
 ```sh
-yq w -i ./apps/podinfo/kustomization.yaml 'resources[0]' abtest.yaml
+yq eval '.resources[0]="abtest.yaml"' -i ./apps/podinfo/kustomization.yaml
 ```
 
 The above configuration will run a canary analysis targeting users based on their browser user-agent.
@@ -274,7 +274,7 @@ The A/B test routing is defined in [apps/podinfo/abtest.yaml](apps/podinfo/abtes
 Bump podinfo version to `5.0.2`:
 
 ```sh
-yq w -i ./apps/podinfo/kustomization.yaml 'images[0].newTag' 5.0.2
+yq eval '.images[0].newTag="5.0.2"' -i ./apps/podinfo/kustomization.yaml
 ```
 
 Commit and push changes:

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ git pull origin main
 Bump podinfo version from `5.0.0` to `5.0.1`:
 
 ```sh
-yq eval '.images[0].newTag="5.0.1"' -i ./apps/podinfo/kustomization.yaml
+yq e '.images[0].newTag="5.0.1"' -i ./apps/podinfo/kustomization.yaml
 ```
 
 Commit and push changes:
@@ -249,7 +249,7 @@ This is particularly useful for frontend applications that require session affin
 Enable A/B testing:
 
 ```sh
-yq eval '.resources[0]="abtest.yaml"' -i ./apps/podinfo/kustomization.yaml
+yq e '.resources[0]="abtest.yaml"' -i ./apps/podinfo/kustomization.yaml
 ```
 
 The above configuration will run a canary analysis targeting users based on their browser user-agent.
@@ -274,7 +274,7 @@ The A/B test routing is defined in [apps/podinfo/abtest.yaml](apps/podinfo/abtes
 Bump podinfo version to `5.0.2`:
 
 ```sh
-yq eval '.images[0].newTag="5.0.2"' -i ./apps/podinfo/kustomization.yaml
+yq e '.images[0].newTag="5.0.2"' -i ./apps/podinfo/kustomization.yaml
 ```
 
 Commit and push changes:

--- a/apps/podinfo/kustomization.yaml
+++ b/apps/podinfo/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - abtest.yaml
+  - canary.yaml
   - deployment.yaml
   - hpa.yaml
   - gateway-route.yaml


### PR DESCRIPTION
Changes:
* Update yq commands for v4
* Reset podinfo kustomization to canary

Note that according to README the initial state is canary and then is changed to abtest in the 5.0.1 mod.